### PR TITLE
Add option to write Silabs compatible ISD event log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # com.zsmartsystems.zigbee.sniffer
 
-This project uses the ```com.zsmartsystems.zigbee.dongle.ember``` driver to provide a ZigBee sniffer interface for Wireshark. The software will connect to an Ember dongle using a serial interface, and send UDP packets on port 17754 which can be received and displayed by Wireshark.
+This project uses the ```com.zsmartsystems.zigbee.dongle.ember``` driver to provide a ZigBee sniffer interface for Wireshark, and optionally write the data to a Silabs compatible event log. The software will connect to an Ember dongle using a serial interface, and send UDP packets on port 17754 which can be received and displayed by Wireshark.
 
 To use Wireshark, the loopback interface needs to be selected, and then a filter ```udp port 17754``` is used to only display ZigBee packets.
+
+```
+usage: ZigBeeSniffer
+-?,--help                         Print usage information
+-a,--ipaddr <remote IP address>   Set the remote IP address
+-b,--baud <baud>                  Set the port baud rate
+-c,--channel <channel id>         Set the ZigBee channel ID
+-f,--flow <type>                  Set the flow control (none | hardware | software)
+-p,--port <port name>             Set the port
+-r,--ipport <remote IP port>      Set the remote IP port
+-s,--silabs <filename>            Log data to a Silabs ISD compatible event log
+```
+
+```
+java -jar ZigBeeSniffer.jar -port /dev/tty.SLAB_USBtoUART -baud 115200 -flow hardware
+```
+

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>com.zsmartsystems.zigbee</groupId>
 			<artifactId>com.zsmartsystems.zigbee</artifactId>
-			<version>1.0.14</version>
+			<version>1.0.15-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>com.zsmartsystems.zigbee</groupId>
 			<artifactId>com.zsmartsystems.zigbee.serial</artifactId>
-			<version>1.0.14</version>
+			<version>1.0.15-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/silabs/SilabsAdapter.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/silabs/SilabsAdapter.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.sniffer.internal.silabs;
+
+import com.zsmartsystems.zigbee.IeeeAddress;
+
+/**
+ * Serialises an adapter in the Silabs ISD log format
+ *
+ * @author Chris Jackson
+ *
+ */
+public class SilabsAdapter extends SilabsIsdFrame {
+    private IeeeAddress address;
+
+    public SilabsAdapter() {
+        packetType = 327686;
+        frameType = "Adapter";
+    }
+
+    public void setAddress(IeeeAddress address) {
+        this.address = address;
+    }
+
+    @Override
+    public String getBuffer() {
+        getHeader();
+        formatValue(address.getValue()[7]);
+        formatValue(address.getValue()[6]);
+        formatValue(address.getValue()[5]);
+        formatValue(address.getValue()[4]);
+        formatValue(address.getValue()[3]);
+        formatValue(address.getValue()[2]);
+        formatValue(address.getValue()[1]);
+        formatValue(address.getValue()[0]);
+
+        return terminateLog();
+    }
+
+}

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/silabs/SilabsIsdFrame.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/silabs/SilabsIsdFrame.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.sniffer.internal.silabs;
+
+/**
+ * A class to encapsulate the ZigBee ISD log for Silabs Simplicity Studio
+ * <p>
+ * [721629332 576 16908322 Packet B1] [ember01] [0A 03 08 E3 FF FF FF FF 07 56 A7 01]
+ * <p>
+ * These fields are decoded as follows:
+ * <p>
+ * <li>721629332 - Timestamp in microseconds when event completed (start time can be inferred from subtracting Duration
+ * from this value)
+ * <li>576 - Event duration in microseconds.
+ * <li>16908322 - Event type ID. This varies for different kinds of trace events (Packets, EZSP traces, NodeInfo traces,
+ * Reset traces, etc.) The one shown denotes a Packet event. These type IDs are not currently documented, so you would
+ * need to derive this empirically through testing if you wish to parse it. Some common ones are 131131 (NodeInfo),
+ * 131138 (Stack Version), 131132 (EZSP), 131133 (ASH), 16908322 (EM250 TX), 16908323 (EM250 RX), 16908324 (EM350 TX),
+ * 16908325 (EM350 RX), 16908329 (EFR TX), 16908330 (EFR RX).
+ * <li>Packet - Event type string. This is the friendly name (as ASCII text) for the event type and will match what
+ * Network Analyzer displays in the event window for this event type.
+ * <li>B1 - Debug protocol's sequence number from the capture source (used to detect gaps in the capture stream)
+ * <li>ember01 - Source device where event was captured.
+ * <li>[0A 03 ... 01] - Event data bytes (prior to any decryption; includes any RadioInfo data appended to end of
+ * packets by the hardware). Note that the first byte for Packet events is generally the Length byte, which represents
+ * (in hexadecimal) the number of bytes (including the Length byte itself) in the transmitted/received packet, up to and
+ * including the CRC16 and not including any status/quality bytes appended by the radio during TX/RX activity.
+ * <p>
+ * Above explanation from this link -:
+ * https://www.silabs.com/community/wireless/zigbee-and-thread/knowledge-base.entry.html/2012/06/28/can_i_examine_captur-uFfw
+ *
+ * @author Chris Jackson
+ *
+ */
+public abstract class SilabsIsdFrame {
+    protected Integer sequence;
+    protected String frameType;
+    private long timestamp;
+    protected int eventDuration = 0;
+    protected int packetType = 0;
+
+    private StringBuilder builder = new StringBuilder();
+
+    private boolean first;
+
+    public SilabsIsdFrame() {
+    }
+
+    /**
+     * @param seqNum the sequence to set
+     */
+    public void setSequence(int sequence) {
+        this.sequence = sequence;
+    }
+
+    /**
+     * @param l the timestamp to set
+     */
+    public void setTimestamp(long l) {
+        this.timestamp = l;
+    }
+
+    protected void formatValue(Integer value) {
+        if (!first) {
+            builder.append(' ');
+        }
+        first = false;
+        if (value == null) {
+            builder.append("XX");
+        } else {
+            builder.append(String.format("%02X", value));
+        }
+    }
+
+    protected void getHeader() {
+        first = true;
+        builder.append("[");
+        builder.append(timestamp);
+        builder.append(' ');
+        builder.append(eventDuration);
+        builder.append(' ');
+        builder.append(packetType);
+        builder.append(' ');
+        builder.append(frameType);
+        builder.append(' ');
+        formatValue(sequence);
+        builder.append("] [ZSmartSystems] [");
+        first = true;
+    }
+
+    protected String terminateLog() {
+        builder.append(']');
+        return builder.toString();
+    }
+
+    public abstract String getBuffer();
+}

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/silabs/SilabsIsdLogFile.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/silabs/SilabsIsdLogFile.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.sniffer.internal.silabs;
+
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+
+/**
+ * This class provides a logger in the Silabs ISD event.log format
+ *
+ * @author Chris Jackson
+ *
+ */
+public class SilabsIsdLogFile {
+    private final PrintWriter writer;
+
+    public SilabsIsdLogFile(String filename) throws FileNotFoundException, UnsupportedEncodingException {
+        writer = new PrintWriter(filename, "UTF-8");
+
+        writer.println("# (c) Ember - InSight Desktop");
+        writer.println("# File created with Z-Smart Systems ZigBeeSniffer");
+        writer.flush();
+    }
+
+    public void write(SilabsIsdFrame frame) {
+        writer.println(frame.getBuffer());
+        writer.flush();
+    }
+
+    public void close() {
+        writer.flush();
+        writer.close();
+    }
+}

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/silabs/SilabsPacketEm350Rx.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/silabs/SilabsPacketEm350Rx.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.sniffer.internal.silabs;
+
+/**
+ * Serialises a data packet from an EM350 to the Silabs ISD log format
+ *
+ * @author Chris Jackson
+ *
+ */
+public class SilabsPacketEm350Rx extends SilabsIsdFrame {
+    private int[] data;
+    private int lqi;
+    private int rssi;
+    private int channel;
+
+    public SilabsPacketEm350Rx() {
+        packetType = 16908325;
+        frameType = "Packet";
+    }
+
+    public void setData(int[] data) {
+        this.data = data;
+    }
+
+    public void setLqi(int lqi) {
+        this.lqi = lqi;
+    }
+
+    public void setRssi(int rssi) {
+        this.rssi = rssi;
+    }
+
+    public void setChannel(int channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public String getBuffer() {
+        // 32uS per byte - extra bytes added to give same value as Simplicity Studio generated logs.
+        eventDuration = (data.length + 9) * 32;
+
+        getHeader();
+        formatValue(data.length);
+        for (int value : data) {
+            formatValue(value);
+        }
+
+        formatValue(lqi);
+        formatValue(rssi);
+        formatValue((channel - 11) * 16);
+
+        return terminateLog();
+    }
+
+}

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/silabs/SilabsPrintf.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/silabs/SilabsPrintf.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.sniffer.internal.silabs;
+
+/**
+ * Serialises an Printf statement in the Silabs ISD log format
+ *
+ * @author Chris Jackson
+ *
+ */
+public class SilabsPrintf extends SilabsIsdFrame {
+    private String string;
+
+    public SilabsPrintf() {
+        packetType = 131074;
+        frameType = "Printf";
+    }
+
+    public void setString(String string) {
+        this.string = string;
+    }
+
+    @Override
+    public String getBuffer() {
+        getHeader();
+        for (char value : string.toCharArray()) {
+            formatValue(Integer.valueOf(value));
+        }
+
+        return terminateLog();
+    }
+
+}

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/silabs/SilabsVersion.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/silabs/SilabsVersion.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016-2018 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.zsmartsystems.zigbee.sniffer.internal.silabs;
+
+/**
+ * Serialises a the stack version in the Silabs ISD log format
+ *
+ * @author Chris Jackson
+ *
+ */
+public class SilabsVersion extends SilabsIsdFrame {
+    private int[] version;
+
+    public SilabsVersion() {
+        packetType = 131138;
+        frameType = "ZnetVer";
+    }
+
+    public void setVersion(String version) {
+        String[] splitVersion = version.split("\\.");
+
+        this.version = new int[4];
+        this.version[0] = Integer.parseInt(splitVersion[0]);
+        this.version[1] = Integer.parseInt(splitVersion[1]);
+        this.version[2] = Integer.parseInt(splitVersion[2]);
+        this.version[3] = Integer.parseInt(splitVersion[3]);
+    }
+
+    @Override
+    public String getBuffer() {
+        getHeader();
+        formatValue(version[0]);
+        formatValue(version[1]);
+        formatValue(version[2]);
+        formatValue(version[3]);
+
+        formatValue(0);
+        formatValue(0);
+        formatValue(0);
+
+        return terminateLog();
+    }
+
+}

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/wireshark/WiresharkZepFrame.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/wireshark/WiresharkZepFrame.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package com.zsmartsystems.zigbee.sniffer;
+package com.zsmartsystems.zigbee.sniffer.internal.wireshark;
 
 import java.util.Arrays;
 
@@ -130,7 +130,7 @@ public class WiresharkZepFrame {
      */
     protected static final long msb1baseTime = -2208988800000L;
 
-    WiresharkZepFrame() {
+    public WiresharkZepFrame() {
     }
 
     /**
@@ -284,11 +284,6 @@ public class WiresharkZepFrame {
         return seconds << 32 | fraction;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder(200);


### PR DESCRIPTION
Adds initial implementation to write an Ember format event log for importing into Simplicity Studio. Some assumptions have been made about the format!
Signed-off-by: Chris Jackson <chris@cd-jackson.com>