### PR TITLE
Provide option to rotate wireshark log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ usage: ZigBeeSniffer
 -c,--channel <channel id>         Set the ZigBee channel ID
 -f,--flow <type>                  Set the flow control (none | hardware | software)
 -l,--local                        Log times in local time
+-m,--maxpcap <length>             Maximum filesize for Wireshark files
 -p,--port <port name>             Set the port
 -r,--ipport <remote IP port>      Set the remote IP port
 -s,--silabs <filename>            Log data to a Silabs ISD compatible event log

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/wireshark/WiresharkPcapFile.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/wireshark/WiresharkPcapFile.java
@@ -61,6 +61,7 @@ import java.io.UnsupportedEncodingException;
  */
 public class WiresharkPcapFile {
     private BufferedOutputStream output;
+    private int bytesWritten;
 
     public static int MAGIC_NUMBER_STANDARD = 0xa1b2c3d4;
 
@@ -74,7 +75,9 @@ public class WiresharkPcapFile {
 
     public void write(WiresharkPcapFrame frame) {
         try {
-            output.write(frame.getBuffer());
+            byte[] buffer = frame.getBuffer();
+            bytesWritten += buffer.length;
+            output.write(buffer);
         } catch (IOException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
@@ -91,11 +94,17 @@ public class WiresharkPcapFile {
         }
     }
 
+    public int getLength() {
+        return bytesWritten;
+    }
+
     public void write(WiresharkPcapHeader header) {
         header.setVersionMajor(2);
         header.setVersionMinor(4);
         try {
-            output.write(header.getBuffer());
+            byte[] buffer = header.getBuffer();
+            bytesWritten += buffer.length;
+            output.write(buffer);
         } catch (IOException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();


### PR DESCRIPTION
Adds an option to set the maximum length of wireshard pcap files. If set, the wireshark file will have an incrementing 4 digit number appended - eg -0001, -0002 etc and sequential files will be limited to the value specified.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>