### PR TITLE
Fixing some values in the ZEP frame sent to Wireshark

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ The software will print an output to the console for each packet that is receive
 If the NCP fails to receive a valid frame with the timeout period set with the ```timeout``` command line parameter, then the NCP will be restarted. This will allow the sniffer to recover from serial port or NCP communications problems. The timer defaults to 30 seconds.
 
 A compiled JAR file can be found [here](https://www.cd-jackson.com/downloads/ZigBeeSniffer.jar) along with [further documentation](https://www.cd-jackson.com/downloads/ZigBeeWiresharkSniffer.pdf).
+
+When using Wireshark to display the packets, the raw IEEE 802.15.4 packet received by the Ember module is first encapsulated in a "TI CC24xx" frame format, then in a ZEPv2 (ZigBee Encapsulation Protocol version 2) frame format before being sent using UDP.
+Using the "TI CC24xx" frame format permit passing the RSSI value but has also limitations:
+* The "RSSI" value is correctly sent using a signed integer value in dBm
+* The "FCS Valid" field is always set to true as the Ember module discards invalid packets
+* The "LQI Correlation Value" is limited to a range of 0 to 127 (whereas the Ember module and the norm are defining this value for the range 0 to 255), so the displayed value is divided by 2.
+
+The real LQI value reported by the module in the range 0 to 255 should be displayed in the ZigBee Encapsulation Protocol section, but due to a bug, this isn't actually the case (see https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=16369).
+
+Due to a limitation in the new Ember modules based on the EFR32, the LQI value isn't based on the bit error rate of the demodulator but is related to the RSSI value (see https://www.silabs.com/community/wireless/zigbee-and-thread/knowledge-base.entry.html/2017/08/15/lqi_in_silicon_labs-vvSq)

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ Using the "TI CC24xx" frame format permit passing the RSSI value but has also li
 
 The real LQI value reported by the module in the range 0 to 255 should be displayed in the ZigBee Encapsulation Protocol section, but due to a bug, this isn't actually the case (see https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=16369).
 
-Due to a limitation in the new Ember modules based on the EFR32, the LQI value isn't based on the bit error rate of the demodulator but is related to the RSSI value (see https://www.silabs.com/community/wireless/zigbee-and-thread/knowledge-base.entry.html/2017/08/15/lqi_in_silicon_labs-vvSq)
+For information on how the LQI is calculated in Silabs chips, refer to https://www.silabs.com/community/wireless/zigbee-and-thread/knowledge-base.entry.html/2017/08/15/lqi_in_silicon_labs-vvSq

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ usage: ZigBeeSniffer
 -s,--silabs <filename>            Log data to a Silabs ISD compatible event log
 -t,--timeout <seconds>            NCP restart timeout in seconds
 -w,--pcap <filename>              Log data to a Wireshark pcap compatible log
+-d,--device-id <device-id>        Set the device ID that will be included in ZEP frame
 ```
 
 Note that the IP address will default to the local host on the assumption that you are running Wireshark on the same computer as the sniffer. The ```ipport``` will default to 17754 which is the port used for the ZigBee Encapsulation Protocol - changing this may stop Wireshark displaying ZigBee data.

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/ZigBeeSniffer.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/ZigBeeSniffer.java
@@ -275,6 +275,7 @@ public class ZigBeeSniffer {
         zepFrame.setData(data);
         zepFrame.setSequence(sequence);
         zepFrame.setTimestamp(captureMillis + timezone);
+        zepFrame.setRssi(rssi);
         System.out.println(zepFrame);
 
         byte[] buffer = zepFrame.getBuffer();

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/ZigBeeSniffer.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/ZigBeeSniffer.java
@@ -64,6 +64,7 @@ public class ZigBeeSniffer {
     static ZigBeeDongleEzsp dongle;
     static EmberMfglib emberMfg;
     static EmberNcp emberNcp;
+    static IeeeAddress localIeeeAddress;
     static long timezone = 0;
     static int wiresharkFileLength = Integer.MAX_VALUE;
     static int wiresharkCounter = 0;
@@ -370,7 +371,7 @@ public class ZigBeeSniffer {
         System.out.println("Ember NCP version     : " + ncpVersion);
 
         emberNcp = dongle.getEmberNcp();
-        IeeeAddress localIeeeAddress = emberNcp.getIeeeAddress();
+        localIeeeAddress = emberNcp.getIeeeAddress();
         System.out.println("Ember NCP EUI         : " + localIeeeAddress);
 
         if (isdFile != null) {

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/ZigBeeSniffer.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/ZigBeeSniffer.java
@@ -272,6 +272,7 @@ public class ZigBeeSniffer {
         WiresharkZepFrame zepFrame = new WiresharkZepFrame();
         zepFrame.setLqi(lqi);
         zepFrame.setChannelId(channelId);
+        zepFrame.setDeviceId((localIeeeAddress.getValue()[1] << 8) + localIeeeAddress.getValue()[0]);
         zepFrame.setData(data);
         zepFrame.setSequence(sequence);
         zepFrame.setTimestamp(captureMillis + timezone);

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/ZigBeeSniffer.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/ZigBeeSniffer.java
@@ -64,6 +64,7 @@ public class ZigBeeSniffer {
     static ZigBeeDongleEzsp dongle;
     static EmberMfglib emberMfg;
     static EmberNcp emberNcp;
+    static String deviceId;
     static IeeeAddress localIeeeAddress;
     static long timezone = 0;
     static int wiresharkFileLength = Integer.MAX_VALUE;
@@ -103,6 +104,8 @@ public class ZigBeeSniffer {
                 .desc("Maximum filesize for Wireshark files").build());
         options.addOption(Option.builder("t").longOpt("timeout").hasArg().argName("seconds")
                 .desc("NCP restart timeout in seconds").build());
+        options.addOption(Option.builder("d").longOpt("device-id").hasArg().argName("device-id")
+                .desc("Set the device ID that will be included in ZEP frame").build());
         options.addOption(Option.builder("l").longOpt("local").desc("Log times in local time").build());
         options.addOption(Option.builder("?").longOpt("help").desc("Print usage information").build());
 
@@ -203,6 +206,10 @@ public class ZigBeeSniffer {
             channelId = 11;
         }
 
+        if (cmdline.hasOption("device-id")) {
+            deviceId = cmdline.getOptionValue("device-id");
+        }
+
         try {
             BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
             while (!in.ready()) {
@@ -273,7 +280,7 @@ public class ZigBeeSniffer {
         WiresharkZepFrame zepFrame = new WiresharkZepFrame();
         zepFrame.setLqi(lqi);
         zepFrame.setChannelId(channelId);
-        zepFrame.setDeviceId((localIeeeAddress.getValue()[1] << 8) + localIeeeAddress.getValue()[0]);
+        zepFrame.setDeviceId(deviceId ? deviceId : (localIeeeAddress.getValue()[1] << 8) + localIeeeAddress.getValue()[0]);
         zepFrame.setData(data);
         zepFrame.setSequence(sequence);
         zepFrame.setTimestamp(captureMillis + timezone);

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/wireshark/WiresharkZepFrame.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/wireshark/WiresharkZepFrame.java
@@ -181,7 +181,7 @@ public class WiresharkZepFrame extends ZigBeeSnifferBinaryFrame {
         this.protocolType = protocolType;
     }
 
-    public void serRssi(int rssi) {
+    public void setRssi(int rssi) {
         this.rssi = rssi;
     }
 

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/wireshark/WiresharkZepFrame.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/wireshark/WiresharkZepFrame.java
@@ -197,7 +197,13 @@ public class WiresharkZepFrame extends ZigBeeSnifferBinaryFrame {
     }
 
     public byte[] getBuffer() {
-        // Patch FCS to be compatible with CC24xx format
+        // The IEEE 802.15.4 packet encapsulated in the ZEP frame must have the "TI CC24xx" format
+        // See figure 21 on page 24 of the CC2420 datasheet: https://www.ti.com/lit/ds/symlink/cc2420.pdf
+        // So, two bytes must be added at the end:
+        // * First byte: RSSI value as a signed 8 bits integer (range -128 to 127)
+        // * Second byte:
+        //   - the most significant bit is set to 1 of the CRC of the frame is correct
+        //   - the 7 least significant bits contain the LQI value as a unsigned 7 bits integer (range 0 to 127)
         data[data.length - 2] = rssi;
         data[data.length - 1] = 0x80 | ((lqi>>1) & 0x7F);
 

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/wireshark/WiresharkZepFrame.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/wireshark/WiresharkZepFrame.java
@@ -254,6 +254,8 @@ public class WiresharkZepFrame extends ZigBeeSnifferBinaryFrame {
         builder.append(String.format("%08X", sequence));
         builder.append(", lqi=");
         builder.append(lqi);
+        builder.append(", rssi=");
+        builder.append(rssi);
         builder.append(", data={");
         boolean first = true;
         for (int val : data) {

--- a/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/wireshark/WiresharkZepFrame.java
+++ b/src/main/java/com/zsmartsystems/zigbee/sniffer/internal/wireshark/WiresharkZepFrame.java
@@ -199,7 +199,7 @@ public class WiresharkZepFrame extends ZigBeeSnifferBinaryFrame {
     public byte[] getBuffer() {
         // Patch FCS to be compatible with CC24xx format
         data[data.length - 2] = rssi;
-        data[data.length - 1] = 0x80;
+        data[data.length - 1] = 0x80 | ((lqi>>1) & 0x7F);
 
         serializeInt8(0x45);
         serializeInt8(0x58);


### PR DESCRIPTION
When using Wireshark to display the packets, the raw IEEE 802.15.4 packet received by the Ember module is first encapsulated in a "TI CC24xx" frame format, then in a ZEPv2 (ZigBee Encapsulation Protocol version 2) frame format before being sent using UDP.
Using the "TI CC24xx" frame format permit passing the RSSI value but has also limitations:
* The "RSSI" value is correctly sent using a signed integer value in dBm
* The "FCS Valid" field is always set to true as the Ember module discards invalid packets
* The "LQI Correlation Value" is limited to a range of 0 to 127 (whereas the Ember module and the norm are defining this value for the range 0 to 255), so the displayed value is divided by 2.

The real LQI value reported by the module in the range 0 to 255 should be displayed in the ZigBee Encapsulation Protocol section, but due to a bug, this isn't actually the case (see https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=16369).

Due to a limitation in the new Ember modules based on the EFR32, the LQI value isn't based on the bit error rate of the demodulator but is related to the RSSI value (see https://www.silabs.com/community/wireless/zigbee-and-thread/knowledge-base.entry.html/2017/08/15/lqi_in_silicon_labs-vvSq)

Credits to @sraillard