### PR TITLE
ZigBee to Zigbee and mention EFR32

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # com.zsmartsystems.zigbee.sniffer
 
-This project uses the ```com.zsmartsystems.zigbee.dongle.ember``` driver to provide a ZigBee sniffer interface for Wireshark, and optionally write the data to a Silabs compatible event log. The software will connect to an Ember dongle using a serial interface, and send UDP packets on port 17754 which can be received and displayed by Wireshark.
+This project uses the ```com.zsmartsystems.zigbee.dongle.ember``` driver for Silicon Labs Ember (EM35x and EFR32) based dongles to provide a Zigbee sniffer interface for Wireshark, and optionally write the data to a Silabs compatible event log. The software will connect to an Ember dongle using a serial interface, and send UDP packets on port 17754 which can be received and displayed by Wireshark.
 
-To use Wireshark, the loopback interface needs to be selected, and then a filter ```udp port 17754``` is used to only display ZigBee packets.
+To use Wireshark, the loopback interface needs to be selected, and then a filter ```udp port 17754``` is used to only display Zigbee packets.
 
 ```
 usage: ZigBeeSniffer
 -?,--help                         Print usage information
 -a,--ipaddr <remote IP address>   Set the remote IP address
 -b,--baud <baud>                  Set the port baud rate
--c,--channel <channel id>         Set the ZigBee channel ID
+-c,--channel <channel id>         Set the Zigbee channel ID
 -o,--rotate <seconds>             Enable channel rotation and set rotation interval (seconds)
 -w,--rotate-start <channel id>    Set the channel rotation range start
 -e,--rotate-end <channel id>      Set the channel rotation range end
@@ -24,7 +24,7 @@ usage: ZigBeeSniffer
 -d,--device-id <device-id>        Set the device ID that will be included in ZEP frame
 ```
 
-Note that the IP address will default to the local host on the assumption that you are running Wireshark on the same computer as the sniffer. The ```ipport``` will default to 17754 which is the port used for the ZigBee Encapsulation Protocol - changing this may stop Wireshark displaying ZigBee data.
+Note that the IP address will default to the local host on the assumption that you are running Wireshark on the same computer as the sniffer. The ```ipport``` will default to 17754 which is the port used for the Zigbee Encapsulation Protocol - changing this may stop Wireshark displaying Zigbee data.
 
 Example command line -:
 
@@ -38,12 +38,12 @@ If the NCP fails to receive a valid frame with the timeout period set with the `
 
 A compiled JAR file can be found [here](https://www.cd-jackson.com/downloads/ZigBeeSniffer.jar) along with [further documentation](https://www.cd-jackson.com/downloads/ZigBeeWiresharkSniffer.pdf).
 
-When using Wireshark to display the packets, the raw IEEE 802.15.4 packet received by the Ember module is first encapsulated in a "TI CC24xx" frame format, then in a ZEPv2 (ZigBee Encapsulation Protocol version 2) frame format before being sent using UDP.
+When using Wireshark to display the packets, the raw IEEE 802.15.4 packet received by the Ember module is first encapsulated in a "TI CC24xx" frame format, then in a ZEPv2 (Zigbee Encapsulation Protocol version 2) frame format before being sent using UDP.
 Using the "TI CC24xx" frame format permit passing the RSSI value but has also limitations:
 * The "RSSI" value is correctly sent using a signed integer value in dBm
 * The "FCS Valid" field is always set to true as the Ember module discards invalid packets
 * The "LQI Correlation Value" is limited to a range of 0 to 127 (whereas the Ember module and the norm are defining this value for the range 0 to 255), so the displayed value is divided by 2.
 
-The real LQI value reported by the module in the range 0 to 255 should be displayed in the ZigBee Encapsulation Protocol section, but due to a bug, this isn't actually the case (see https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=16369).
+The real LQI value reported by the module in the range 0 to 255 should be displayed in the Zigbee Encapsulation Protocol section, but due to a bug, this isn't actually the case (see https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=16369).
 
 For information on how the LQI is calculated in Silabs chips, refer to https://www.silabs.com/community/wireless/zigbee-and-thread/knowledge-base.entry.html/2017/08/15/lqi_in_silicon_labs-vvSq


### PR DESCRIPTION
"ZigBee" -> "Zigbee" as has the Zigbee Alliance has officially changed its trademarked name to stop using bicapitalization as its brand identity.

Please note that all com.zsmartsystems software looks to be using the old branding, as again, Zigbee should always a lowercase B, not a capital.

I'm unable to find a definitive reference for when the "rebranding" occurred, but it did. 

zigbeealliance.org consistently uses the form with lowercase b, and contains numerous references like in https://zigbeealliance.org/solution_type/zigbee/ and https://zigbeealliance.org/developer_resources/zigbee-specification/

"Please note that this uses old branding, Zigbee is always a lowercase B, not a capital. This change occurred shortly after the official release of this document."