### PR TITLE
feat: bundle slf4j-simple to allow debugging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
 			<version>1.4</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>1.7.36</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
This helps understand issues when [things go wrong](https://github.com/zsmartsystems/com.zsmartsystems.zigbee.sniffer/issues/30).

Usage:
```
# java -Dorg.slf4j.simpleLogger.defaultLogLevel=debug -jar target/com.zsmartsystems.zigbee.sniffer-1.0.1-SNAPSHOT.jar -baud 115200 -flow software -port /dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_548xxxxxx988-if00-port0 -c 15
```

Without this change, the following is traced:
```
# java -Dorg.slf4j.simpleLogger.defaultLogLevel=debug -jar com.zsmartsystems.zigbee.sniffer-1.0.1.jar -baud 115200 -flow software -port /dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_548aabf08b91ed11809ccad13b20a988-if00-port0 -c 15
Z-Smart Systems Ember Packet Sniffer
NCP initialisation starting...
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Opened serial port /dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_548xxxxxx988-if00-port0 at 115200
Unable to communicate with Ember NCP
Unable to initialise NCP
```